### PR TITLE
Added a delegate callback to allow the picker to show activity on a given date.

### DIFF
--- a/DayFlow/DFDatePickerDayCell.h
+++ b/DayFlow/DFDatePickerDayCell.h
@@ -5,5 +5,6 @@
 
 @property (nonatomic, readwrite, assign) DFDatePickerDate date;
 @property (nonatomic, getter=isEnabled) BOOL enabled;
+@property (nonatomic, assign) BOOL hasActivity;
 
 @end

--- a/DayFlow/DFDatePickerDayCell.m
+++ b/DayFlow/DFDatePickerDayCell.m
@@ -39,6 +39,12 @@
 	[self setNeedsLayout];
 }
 
+- (void) setHasActivity:(BOOL)hasActivity
+{
+    _hasActivity = hasActivity;
+    [self setNeedsLayout];
+}
+
 - (void) layoutSubviews {
 	
 	[super layoutSubviews];
@@ -88,6 +94,12 @@
 		CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
 		[[NSString stringWithFormat:@"%i", self.date.day] drawInRect:textBounds withFont:font lineBreakMode:NSLineBreakByCharWrapping alignment:NSTextAlignmentCenter];
 		
+        if (self.hasActivity){
+            CGFloat circleWidth = 5.0;
+            CGRect circleRect = (CGRectMake((self.bounds.size.width / 2) - (circleWidth / 2), self.bounds.size.height - (circleWidth * 2), circleWidth, circleWidth));
+            CGContextFillEllipseInRect(context, circleRect);
+        }
+        
 		UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 		UIGraphicsEndImageContext();
 		

--- a/DayFlow/DFDatePickerView.h
+++ b/DayFlow/DFDatePickerView.h
@@ -1,9 +1,16 @@
 #import <UIKit/UIKit.h>
 
+@class DFDatePickerView;
+
+@protocol DFDatePickerViewDataSource <NSObject>
+- (BOOL) datePickerView:(DFDatePickerView *)datePickerView shouldShowActivityOnDate:(NSDate *)date;
+@end
+
 @interface DFDatePickerView : UIView
 
 - (instancetype) initWithCalendar:(NSCalendar *)calendar;
 
 @property (nonatomic, readwrite, strong) NSDate *selectedDate;
+@property (nonatomic, weak) id <DFDatePickerViewDataSource> dataSource;
 
 @end

--- a/DayFlow/DFDatePickerView.m
+++ b/DayFlow/DFDatePickerView.m
@@ -318,6 +318,7 @@ static NSString * const DFDatePickerViewMonthHeaderIdentifier = @"monthHeader";
 	cell.date = cellPickerDate;
 	cell.enabled = ((firstDayPickerDate.year == cellPickerDate.year) && (firstDayPickerDate.month == cellPickerDate.month));
 	cell.selected = [self.selectedDate isEqualToDate:cellDate];
+    cell.hasActivity = [self.dataSource datePickerView:self shouldShowActivityOnDate:cellDate];
 	
 	return cell;
 	

--- a/DayFlow/DFDatePickerViewController.h
+++ b/DayFlow/DFDatePickerViewController.h
@@ -5,6 +5,7 @@
 @protocol DFDatePickerViewControllerDelegate
 
 - (void) datePickerViewController:(DFDatePickerViewController *)controller didSelectDate:(NSDate *)date;
+- (BOOL) datePickerViewController:(DFDatePickerViewController *)controller shouldShowActivityOnDate:(NSDate *)date;
 
 @end
 

--- a/DayFlow/DFDatePickerViewController.m
+++ b/DayFlow/DFDatePickerViewController.m
@@ -1,5 +1,8 @@
 #import "DFDatePickerViewController.h"
 
+@interface DFDatePickerViewController () <DFDatePickerViewDataSource>
+@end
+
 @implementation DFDatePickerViewController
 @synthesize datePickerView = _datePickerView;
 
@@ -13,6 +16,7 @@
 		_datePickerView = [DFDatePickerView new];
 		_datePickerView.frame = self.view.bounds;
 		_datePickerView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+        _datePickerView.dataSource = self;
 	}
 	return _datePickerView;
 }
@@ -35,6 +39,11 @@
 			[self.delegate datePickerViewController:self didSelectDate:toDate];
 		}
 	}
+}
+
+- (BOOL) datePickerView:(DFDatePickerView *)datePickerView shouldShowActivityOnDate:(NSDate *)date
+{
+    return [self.delegate datePickerViewController:self shouldShowActivityOnDate:date];
 }
 
 @end


### PR DESCRIPTION
Like the iOS calendar app:

![screen shot 2013-05-03 at 17 43 05](https://f.cloud.github.com/assets/34273/459981/f7f37e38-b410-11e2-929a-59b260fdf9e6.png)

Don't mind if you decide not to accept the Pull Request. DayFlow is perfect for something I'm working on, but needed this tiny tweak. I figured I'd send it back in case you want it.

Thanks!
