### PR TITLE
Fixed content offset when shifting dates

### DIFF
--- a/DayFlow/DFDatePickerView.m
+++ b/DayFlow/DFDatePickerView.m
@@ -183,7 +183,8 @@ static NSString * const DFDatePickerViewMonthHeaderIdentifier = @"monthHeader";
 	NSIndexPath *fromIndexPath = [cv indexPathForCell:((UICollectionViewCell *)visibleCells[0]) ];
 	NSInteger fromSection = fromIndexPath.section;
 	NSDate *fromSectionOfDate = [self dateForFirstDayInSection:fromSection];
-	CGPoint fromSectionOrigin = [self convertPoint:[cvLayout layoutAttributesForItemAtIndexPath:fromIndexPath].frame.origin fromView:cv];
+    UICollectionViewLayoutAttributes *fromAttrs = [cvLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:fromSection]];
+	CGPoint fromSectionOrigin = [self convertPoint:fromAttrs.frame.origin fromView:cv];
 	
 	_fromDate = [self pickerDateFromDate:[self.calendar dateByAddingComponents:components toDate:[self dateFromPickerDate:self.fromDate] options:0]];
 	_toDate = [self pickerDateFromDate:[self.calendar dateByAddingComponents:components toDate:[self dateFromPickerDate:self.toDate] options:0]];


### PR DESCRIPTION
The content offset was not being set correctly after shifting dates for infinite scrolling. This was due to fromSectionOrigin not actually pointing to the first item in the section. This small change fixes the issue.
