### PR TITLE
Activity dots can now be shown on each cell

### DIFF
--- a/DayFlow/DFDatePickerDayCell.h
+++ b/DayFlow/DFDatePickerDayCell.h
@@ -5,5 +5,6 @@
 
 @property (nonatomic, readwrite, assign) DFDatePickerDate date;
 @property (nonatomic, getter=isEnabled) BOOL enabled;
+@property (nonatomic, assign) BOOL hasActivity;
 
 @end

--- a/DayFlow/DFDatePickerDayCell.m
+++ b/DayFlow/DFDatePickerDayCell.m
@@ -6,6 +6,7 @@
 + (id) fetchObjectForKey:(id)key withCreator:(id(^)(void))block;
 @property (nonatomic, readonly, strong) UIImageView *imageView;
 @property (nonatomic, readonly, strong) UIView *overlayView;
+@property (nonatomic, strong) UIImageView *activityDot;
 @end
 
 @implementation DFDatePickerDayCell
@@ -37,6 +38,12 @@
 - (void) setSelected:(BOOL)selected {
 	[super setSelected:selected];
 	[self setNeedsLayout];
+}
+
+- (void) setHasActivity:(BOOL)hasActivity
+{
+    _hasActivity = hasActivity;
+    [self setNeedsLayout];
 }
 
 - (void) layoutSubviews {
@@ -95,6 +102,26 @@
 		
 	}];
 	
+	self.activityDot.image = [[self class] fetchObjectForKey:[[self class] cacheKeyForActivity:self.hasActivity] withCreator:^id{
+		UIGraphicsBeginImageContextWithOptions(self.activityDot.bounds.size, YES, self.window.screen.scale);
+		CGContextRef context = UIGraphicsGetCurrentContext();
+		
+		if (self.hasActivity){
+			
+			CGContextSetFillColorWithColor(context, [UIColor colorWithRed:53.0f/256.0f green:145.0f/256.0f blue:195.0f/256.0f alpha:1.0f].CGColor);
+			CGContextFillRect(context, self.activityDot.bounds);
+			
+			CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
+			CGContextFillEllipseInRect(context, self.activityDot.bounds);
+		}
+		
+		UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+		UIGraphicsEndImageContext();
+		return image;
+	}];
+	
+	self.activityDot.hidden = !self.hasActivity;
+	
 	self.overlayView.hidden = !(self.selected || self.highlighted);
 
 }
@@ -119,6 +146,17 @@
 	return _imageView;
 }
 
+- (UIImageView *) activityDot {
+	if (!_activityDot) {
+		CGFloat circleWidth = 5.0;
+		CGRect circleRect = (CGRectMake((self.bounds.size.width / 2) - (circleWidth / 2), self.bounds.size.height - (circleWidth * 2), circleWidth, circleWidth));
+		
+		_activityDot = [[UIImageView alloc] initWithFrame:circleRect];
+		[self.contentView addSubview:_activityDot];
+	}
+	return _activityDot;
+}
+
 + (NSCache *) imageCache {
 	static NSCache *cache;
 	static dispatch_once_t onceToken;
@@ -130,6 +168,10 @@
 
 + (id) cacheKeyForPickerDate:(DFDatePickerDate)date {
 	return @(date.day);
+}
+
++ (id) cacheKeyForActivity:(BOOL)hasActivity {
+	return @(hasActivity);
 }
 
 + (id) fetchObjectForKey:(id)key withCreator:(id(^)(void))block {

--- a/DayFlow/DFDatePickerDayCell.m
+++ b/DayFlow/DFDatePickerDayCell.m
@@ -167,7 +167,7 @@
 }
 
 + (id) cacheKeyForActivity:(BOOL)hasActivity {
-	return @(hasActivity);
+	return [NSString stringWithFormat:@"HasActivity-%d", hasActivity];
 }
 
 + (id) fetchObjectForKey:(id)key withCreator:(id(^)(void))block {

--- a/DayFlow/DFDatePickerDayCell.m
+++ b/DayFlow/DFDatePickerDayCell.m
@@ -103,14 +103,10 @@
 	}];
 	
 	self.activityDot.image = [[self class] fetchObjectForKey:[[self class] cacheKeyForActivity:self.hasActivity] withCreator:^id{
-		UIGraphicsBeginImageContextWithOptions(self.activityDot.bounds.size, YES, self.window.screen.scale);
+		UIGraphicsBeginImageContextWithOptions(self.activityDot.bounds.size, NO, self.window.screen.scale);
 		CGContextRef context = UIGraphicsGetCurrentContext();
 		
 		if (self.hasActivity){
-			
-			CGContextSetFillColorWithColor(context, [UIColor colorWithRed:53.0f/256.0f green:145.0f/256.0f blue:195.0f/256.0f alpha:1.0f].CGColor);
-			CGContextFillRect(context, self.activityDot.bounds);
-			
 			CGContextSetFillColorWithColor(context, [UIColor whiteColor].CGColor);
 			CGContextFillEllipseInRect(context, self.activityDot.bounds);
 		}

--- a/DayFlow/DFDatePickerView.h
+++ b/DayFlow/DFDatePickerView.h
@@ -1,9 +1,19 @@
 #import <UIKit/UIKit.h>
 
+@class DFDatePickerView;
+
+@protocol DFDatePickerViewDataSource <NSObject>
+
+- (BOOL) datePickerView:(DFDatePickerView *)datePickerView shouldShowActivityOnDate:(NSDate *)date;
+
+@end
+
 @interface DFDatePickerView : UIView
 
 - (instancetype) initWithCalendar:(NSCalendar *)calendar;
 
 @property (nonatomic, readwrite, strong) NSDate *selectedDate;
+
+@property (nonatomic, weak) id <DFDatePickerViewDataSource> dataSource;
 
 @end

--- a/DayFlow/DFDatePickerView.m
+++ b/DayFlow/DFDatePickerView.m
@@ -183,7 +183,8 @@ static NSString * const DFDatePickerViewMonthHeaderIdentifier = @"monthHeader";
 	NSIndexPath *fromIndexPath = [cv indexPathForCell:((UICollectionViewCell *)visibleCells[0]) ];
 	NSInteger fromSection = fromIndexPath.section;
 	NSDate *fromSectionOfDate = [self dateForFirstDayInSection:fromSection];
-	CGPoint fromSectionOrigin = [self convertPoint:[cvLayout layoutAttributesForItemAtIndexPath:fromIndexPath].frame.origin fromView:cv];
+	UICollectionViewLayoutAttributes *fromAttrs = [cvLayout layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:fromSection]];
+	CGPoint fromSectionOrigin = [self convertPoint:fromAttrs.frame.origin fromView:cv];
 	
 	_fromDate = [self pickerDateFromDate:[self.calendar dateByAddingComponents:components toDate:[self dateFromPickerDate:self.fromDate] options:0]];
 	_toDate = [self pickerDateFromDate:[self.calendar dateByAddingComponents:components toDate:[self dateFromPickerDate:self.toDate] options:0]];
@@ -318,6 +319,7 @@ static NSString * const DFDatePickerViewMonthHeaderIdentifier = @"monthHeader";
 	cell.date = cellPickerDate;
 	cell.enabled = ((firstDayPickerDate.year == cellPickerDate.year) && (firstDayPickerDate.month == cellPickerDate.month));
 	cell.selected = [self.selectedDate isEqualToDate:cellDate];
+	cell.hasActivity = [self.dataSource datePickerView:self shouldShowActivityOnDate:cellDate];
 	
 	return cell;
 	

--- a/DayFlow/DFDatePickerViewController.h
+++ b/DayFlow/DFDatePickerViewController.h
@@ -5,6 +5,7 @@
 @protocol DFDatePickerViewControllerDelegate
 
 - (void) datePickerViewController:(DFDatePickerViewController *)controller didSelectDate:(NSDate *)date;
+- (BOOL) datePickerViewController:(DFDatePickerViewController *)controller shouldShowActivityOnDate:(NSDate *)date;
 
 @end
 

--- a/DayFlow/DFDatePickerViewController.m
+++ b/DayFlow/DFDatePickerViewController.m
@@ -1,5 +1,9 @@
 #import "DFDatePickerViewController.h"
 
+@interface DFDatePickerViewController () <DFDatePickerViewDataSource>
+
+@end
+
 @implementation DFDatePickerViewController
 @synthesize datePickerView = _datePickerView;
 
@@ -13,6 +17,7 @@
 		_datePickerView = [DFDatePickerView new];
 		_datePickerView.frame = self.view.bounds;
 		_datePickerView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
+		_datePickerView.dataSource = self;
 	}
 	return _datePickerView;
 }
@@ -35,6 +40,11 @@
 			[self.delegate datePickerViewController:self didSelectDate:toDate];
 		}
 	}
+}
+
+- (BOOL) datePickerView:(DFDatePickerView *)datePickerView shouldShowActivityOnDate:(NSDate *)date
+{
+    return [self.delegate datePickerViewController:self shouldShowActivityOnDate:date];
 }
 
 @end


### PR DESCRIPTION
This is the long-awaited followup to #2 - really sorry about the delay. I ended up putting this project on hold, and I'm only just getting back to it.

Anyway, this pull request lets you specify whether there should be an activity dot on a given date. I've taken your suggestion on implementing it, and it appears to do the trick nicely.

Screenshot:
![screen shot 2014-02-26 at 17 44 29](https://f.cloud.github.com/assets/34273/2273247/af768220-9f0d-11e3-9989-22f4e040f144.png)
